### PR TITLE
Add support for WikiLinks

### DIFF
--- a/commonmark-doc/scribblings/commonmark.scrbl
+++ b/commonmark-doc/scribblings/commonmark.scrbl
@@ -68,6 +68,9 @@
 @(define-syntax-rule (cm-examples body ...)
    (examples #:eval (make-commonmark-eval) #:once body ...))
 
+@(define MediaWiki @hyperlink["https://www.mediawiki.org/"]{MediaWiki})
+@(define WikiLink @hyperlink["https://www.mediawiki.org/wiki/Help:Links#Internal_links"]{WikiLink})
+
 @defmodule[commonmark]{
 
 The @racketmodname[commonmark] library implements a @|CommonMark|-compliant Markdown parser. Currently, it passes all test cases in @hyperlink["https://spec.commonmark.org/0.30/"]{v0.30 of the specification}. By default, only the Markdown features specified by @CommonMark are supported, but non-standard support for @tech{footnotes} can be optionally enabled; see the @secref{extensions} section of this manual for more details.
@@ -144,6 +147,16 @@ Enables or disables @tech{footnote} parsing, which is an @tech{extension} to the
 Note that the value of @racket[current-parse-footnotes?] only affects parsing, @emph{not} rendering. If a @tech{document} containing @tech{footnotes} is rendered to HTML, the @tech{footnotes} will still be rendered even if @racket[(current-parse-footnotes?)] is @racket[#f].
 
 @history[#:added "1.1"]}
+
+@defboolparam[current-parse-wikilinks? parse-wikilinks? #:value #f]{
+Enables or disables the parsing of @|WikiLink|s. Specifically, settings this @reftech{parameter} to a value other than @racket[#f] enables the parsing of @MediaWiki internal links and piped links as @tech{wikilink}s. More complex MediaWiki link types, such as the pipe trick or word-ending links are not supported.
+
+Importantly, @tech{wikilink} parsing breaks compliance with the @CommonMark specification!
+
+@(cm-examples
+  #:label "Example:"
+  (parameterize ([current-parse-wikilinks? #t])
+    (string->document "[[link]] and [[link|label]]")))}
 
 @section[#:tag "rendering-html"]{Rendering HTML}
 @declare-exporting[commonmark/render/html commonmark]
@@ -310,7 +323,7 @@ A @deftech{thematic break} is a @tech{block}. It is usually rendered as a horizo
 @defproc[(inline? [v any/c]) boolean?]{
 @see-cm[@tech{inline content} @cm-section{Blocks and inlines}]
 
-Returns @racket[#t] if @racket[v] is @deftech{inline content}: a @reftech{string}, @tech{italic span}, @tech{bold span}, @tech{code span}, @tech{link}, @tech{image}, @tech{footnote reference}, @tech{HTML span}, @tech{hard line break}, or @reftech{list} of @tech{inline content}. Otherwise, returns @racket[#f].}
+Returns @racket[#t] if @racket[v] is @deftech{inline content}: a @reftech{string}, @tech{italic span}, @tech{bold span}, @tech{code span}, @tech{link}, @tech{wikilink}, @tech{image}, @tech{footnote reference}, @tech{HTML span}, @tech{hard line break}, or @reftech{list} of @tech{inline content}. Otherwise, returns @racket[#f].}
 
 @defstruct*[italic ([content inline?]) #:transparent]{
 @see-cm[@tech{italic spans} @cm-section{Emphasis and strong emphasis}]
@@ -343,6 +356,12 @@ An @deftech{image} is @tech{inline content} with a source path or URL that shoul
 A @tech{footnote reference} is @tech{inline content} that references a @tech{footnote definition} with a matching @tech{footnote label}. In HTML output, it corresponds to a superscript @tt{<a>} element.
 
 @history[#:added "1.1"]}
+
+@defstruct*[wikilink ([content inline?] [dest string?]) #:transparent]{
+
+A @deftech{wikilink} is @tech{inline content} that contains nested @tech{inline content} and a link destination. Following the definitions of @|WikiLink|s in @MediaWiki, the content is identical to the link destination in case of internal links.
+
+In HTML output, a @tech{wikilink} corresponds to an @tt{<a>} element.}
 
 @defstruct*[html ([content string?]) #:transparent]{
 @see-cm[@tech{HTML spans} @cm-section{Raw HTML}]

--- a/commonmark-doc/scribblings/commonmark/private/scribble-render.rkt
+++ b/commonmark-doc/scribblings/commonmark/private/scribble-render.rkt
@@ -126,6 +126,8 @@
            (link-element #f _ (footnote-definition-tag label))
            (target-element #f _ (footnote-reference-tag label ref-num))
            (element 'superscript)))
+    (define/override (render-wikilink content dest)
+      (element (style #f (list (make-target-url dest))) content))
 
     (define/override (render-footnote-definition blocks label ref-count)
       (define multiple-refs? (> ref-count 1))

--- a/commonmark-lib/commonmark/parse.rkt
+++ b/commonmark-lib/commonmark/parse.rkt
@@ -2,10 +2,12 @@
 
 (require racket/contract
          "private/struct.rkt"
-         "private/parse/block.rkt")
+         "private/parse/block.rkt"
+         "private/parse/inline.rkt")
 
 (provide (contract-out
           [read-document (-> input-port? document?)]
           [string->document (-> string? document?)]
 
-          [current-parse-footnotes? (parameter/c any/c boolean?)]))
+          [current-parse-footnotes? (parameter/c any/c boolean?)]
+          [current-parse-wikilinks? (parameter/c any/c boolean?)]))

--- a/commonmark-lib/commonmark/private/render.rkt
+++ b/commonmark-lib/commonmark/private/render.rkt
@@ -86,6 +86,7 @@
               render-image
               render-html
               render-footnote-reference
+              render-wikilink
 
               render-footnote-definition)
 
@@ -156,7 +157,9 @@
                    (render-html content)]
                   [(footnote-reference label)
                    (match-define (footnote-info defn-num ref-num) (resolve-footnote-reference label))
-                   (render-footnote-reference label defn-num ref-num)]))))
+                   (render-footnote-reference label defn-num ref-num)]
+                  [(wikilink content dest)
+                   (render-wikilink (render-inline content) dest)]))))
 
     (define/public (render-inlines contents)
       (for*/list ([content (in-list contents)]

--- a/commonmark-lib/commonmark/private/struct.rkt
+++ b/commonmark-lib/commonmark/private/struct.rkt
@@ -20,7 +20,8 @@
          (struct-out link)
          (struct-out image)
          (struct-out html)
-         (struct-out footnote-reference))
+         (struct-out footnote-reference)
+         (struct-out wikilink))
 
 ;; -----------------------------------------------------------------------------
 
@@ -57,7 +58,8 @@
       (link? v)
       (image? v)
       (html? v)
-      (footnote-reference? v)))
+      (footnote-reference? v)
+      (wikilink? v)))
 
 (define-values [line-break line-break?]
   (let ()
@@ -70,3 +72,4 @@
 (struct image (description source title) #:transparent)
 (struct html (content) #:transparent)
 (struct footnote-reference (label) #:transparent)
+(struct wikilink (content dest) #:transparent)

--- a/commonmark-lib/commonmark/render/html.rkt
+++ b/commonmark-lib/commonmark/render/html.rkt
@@ -98,6 +98,8 @@
             (a ([id ,(footnote-reference-anchor label ref-num)]
                 [href ,(~a "#" (footnote-definition-anchor (uri-path-segment-encode label)))])
                ,(~a defn-num))))
+    (define/override (render-wikilink content dest)
+      `(a ([href ,dest]) ,@content))
 
     (define/override (render-footnote-definition blocks label ref-count)
       (define encoded-label (uri-path-segment-encode label))

--- a/commonmark-lib/commonmark/struct.rkt
+++ b/commonmark-lib/commonmark/struct.rkt
@@ -26,4 +26,5 @@
           (struct link ([content inline?] [dest string?] [title (or/c string? #f)]))
           (struct image ([description inline?] [source string?] [title (or/c string? #f)]))
           (struct html ([content string?]))
-          (struct footnote-reference ([label string?]))))
+          (struct footnote-reference ([label string?]))
+          (struct wikilink ([content inline?] [dest string?]))))

--- a/commonmark-test/tests/commonmark/parse/wikilink.rkt
+++ b/commonmark-test/tests/commonmark/parse/wikilink.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+
+(require commonmark
+         commonmark/struct
+         rackunit)
+
+(parameterize ([current-parse-wikilinks? #t])
+  (check-equal? (string->document "[[example]]")
+                (document (list (paragraph (wikilink "example" "example"))) '()))
+  (check-equal? (string->document "[[destination|label]]")
+                (document (list (paragraph (wikilink "label" "destination"))) '()))
+  (check-equal? (string->document "[[destination|label with **bold** markup]]")
+                (document (list (paragraph (wikilink (list "label with " (bold "bold") " markup") "destination"))) '()))
+  (check-equal? (string->document "[[lorem [[link]] ipsum]]")
+                (document (list (paragraph (list "[[lorem " (wikilink "link" "link") " ipsum]]"))) '()))
+  (check-equal? (string->document "[[unclosed")
+                (document (list (paragraph "[[unclosed")) '()))
+  (check-equal? (string->document "[[]]")
+                (document (list (paragraph "[[]]")) '())))


### PR DESCRIPTION
Dear Alexis

I would like to use your excellent racket-commonmark library to parse and process notes taken with [Obsidian](https://obsidian.md/). Obsidian generates [CommonMark, with some custom syntax](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/Guides/Markdown+Syntax). Most importantly, Obsidian makes heavy use of WikiLinks, such as `[[link]]` and `[[link|link with custom label]]`.

The commit in this pull request introduces
- `current-parse-wikilinks?`, a parameter to enable the parsing of WikiLinks (with default value `#f`), and
- `wikilink`, a struct corresponding to the new WikiLink inline content type.

I am not aware of a formal definition of WikiLinks, and parsing of WikiLinks differs substantially across implementations. Here, I have attempted to follow the behavior of [MediaWiki](https://www.mediawiki.org/wiki/Help:Links), arguably the most widely-used wiki engine. (See, for example, the note on nested WikiLinks in `inline.rkt`.)

Importantly, **enabling WikiLink parsing breaks conformance with the CommonMark spec**! The following four conformance tests for CommonMark 0.30 fail when WikiLink parsing is enabled:

- Example 519: `![[[foo](uri1)](uri2)](uri3)\n`
- Example 547: `[[[foo]]]\n\n[[[foo]]]: /url\n`
- Example 558: `[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n`
- Example 589: `![[foo]]\n\n[[foo]]: /url \"title\"\n`

Thus, I fully understand if you're not interested in this pull request.